### PR TITLE
Don't check collisions against self

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,7 +423,7 @@ setInterval(
     // Compute collisions
     for(k = 9; k--;){
       for(i = objects.length; i--;){
-        for(j = objects.length; j-- > i;){
+        for(j = objects.length; --j > i;){
           
           // Test bounds
           if(boundTest(objects[i], objects[j])){


### PR DESCRIPTION
By using the prefix decrement, [the value used in the comparison is the decremented value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Decrement), as opposed to the non-decremented value when done as a postfix operation.

An example to highlight the difference:

```
var j = 2; --j < 2
> true
var j = 2; j-- < 2
> false
```